### PR TITLE
fix: Fix input defaults

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   collapsibleThreshold:
     description: 'Number of lock changes, which will result in collapsed comment content an addition of summary table.'
     required: false
-    default: '25'
+    default: 25
   failOnDowngrade:
     description: 'When a dependency downgrade is detected, fail the action.'
     required: false
-    default: 'false'
+    default: false
   path:
     description: 'Path to the "package-lock.json" file in the repository. Default value points to the file at project root.'
     required: false
@@ -22,7 +22,7 @@ inputs:
   updateComment:
     description: 'Update the comment on each new commit. If value is set to "false", bot will post a new one on each change.'
     required: false
-    default: 'true'
+    default: true
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
The default inputs were not being correctly used, in particular `updateComment` was defaulting to `false`. I believe this is because the default should be `true`, not `'true'`, based on Github's own actions e.g. https://github.com/actions/checkout/blob/main/action.yml#L59.